### PR TITLE
Hotfix 1

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -110,13 +110,9 @@
         "sf_ai_avoidance_registry.h": "c",
         "sf_utility_hooks.h": "c",
         "sf_onhit_registry.h": "c",
-<<<<<<< HEAD
         "text_encoding": "c",
         "sf_ai_structures.h": "c",
         "sf_spell_structures.h": "c"
-=======
-        "sf_vanilla_fix_hook.h": "c"
->>>>>>> hotfix
     },
     "C_Cpp.errorSquiggles": "disabled",
     "makefile.makePath": "mingw32-make",

--- a/src/internal/core/hooks/sf_phys_effect_hook.c
+++ b/src/internal/core/hooks/sf_phys_effect_hook.c
@@ -55,7 +55,7 @@ void __thiscall sf_phys_effect_hook(SF_CGdEffect *_this, uint16_t effect_id)
                     }
 
                 }
-                toolboxAPI.dealDamage(_this->SF_CGdFigureToolBox, source_id, target_id, damage, isMagicDamage, 0, 0);
+                toolboxAPI.dealDamage(_this->SF_CGdFigureToolBox, source_id, target_id, damage, isMagicDamage, 1, 0);
                 //Monument protection handler
                 uint32_t mana_cost = effectAPI.getEffectXData(_this, effect_id, EFFECT_MANA_COST);
                 if (mana_cost != 0)


### PR DESCRIPTION
Fixed ranged damage missing corresponding flag.
Steelskin and shield were broken due to this. 